### PR TITLE
Affiliate instructions update

### DIFF
--- a/src/Models/Affiliate.php
+++ b/src/Models/Affiliate.php
@@ -74,6 +74,11 @@ class Affiliate extends Model
         return $this->plan->commission_percentage / 100;
     }
 
+    public function commissionDuration()
+    {
+        return $this->plan->months_of_commission;
+    }
+
     public function commissionAmount()
     {
         return new Currency($this->plan->commission_amount);

--- a/src/resources/views/affiliates/instructions.blade.php
+++ b/src/resources/views/affiliates/instructions.blade.php
@@ -11,7 +11,13 @@
     @if($affiliate->commissionAmount()->value() > 0)
     <p>You receive a {{$affiliate->commissionAmount()}} commission from every user you refer.</p>
     @elseif($affiliate->commissionPercentage() > 0)
-    <p>You receive a {{round($affiliate->commissionPercentage()*100)}}% commission from every user you refer.</p>
+    <p>You receive a<br /><strong>{{round($affiliate->commissionPercentage()*100)}}% commission</strong>
+        @if($affiliate->commissionDuration() > 0)
+            <br />for the first <strong>{{$affiliate->commissionDuration()}} months</strong> of the subscription
+            @else
+            <br />for the <strong>lifetime</strong> of the subscription
+            @endif
+        <br />from every user you refer.</p>
     @endif
     @if($affiliate->discountAmount()->value() > 0)
     <p>Users who sign up through your link receive a {{$affiliate->discountAmount()}} discount.</p>

--- a/src/resources/views/affiliates/instructions.blade.php
+++ b/src/resources/views/affiliates/instructions.blade.php
@@ -9,7 +9,13 @@
 <div>
     <h3>Your Affiliate Plan</h3>
     @if($affiliate->commissionAmount()->value() > 0)
-    <p>You receive a {{$affiliate->commissionAmount()}} commission from every user you refer.</p>
+        <p>You receive a <br /><strong>{{$affiliate->commissionAmount()}} commission</strong>
+            @if($affiliate->commissionDuration() > 0)
+                <br />for the first <strong>{{$affiliate->commissionDuration()}} months</strong> of the subscription
+            @else
+                <br />for the <strong>lifetime</strong> of the subscription
+            @endif
+            <br />from every user you refer.</p>
     @elseif($affiliate->commissionPercentage() > 0)
     <p>You receive a<br /><strong>{{round($affiliate->commissionPercentage()*100)}}% commission</strong>
         @if($affiliate->commissionDuration() > 0)


### PR DESCRIPTION
Added a commissionDuration method to the Affiliate model that returns the number of months for the commission.
Updated the text on the instructions to better define the commission plan

For example:
You receive a
$10.00 commission
for the first 12 months of the subscription
from every user you refer.